### PR TITLE
Add new aura icon ID for Dining category

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -331,6 +331,7 @@ local gOutfitter_SpellNameSpecialID = {
 
 local gOutfitter_AuraIconSpecialID = {
 	["INV_Misc_Fork&Knife"] = "Dining",
+	["INV_Misc_Food_28"] = "Dining",
 	["Spell_Shadow_Shadowform"] = "Shadowform",
 	["Spell_Nature_SpiritWolf"] = "GhostWolf",
 	["Ability_Rogue_FeignDeath"] = "Feigning",


### PR DESCRIPTION
This if "Dining" fix for oranges (Conjured Mana Orange)

This update includes an additional icon ("INV_Misc_Food_28") to the Dining category in the aura icon special IDs. It ensures proper categorization and improves functionality for identifying Dining-related icons.