### PR TITLE
Add NonCombat Outfit System and Tree of Life Form Support

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -695,6 +695,7 @@ function Outfitter_OnLoad()
 
 	-- For boss/trash outfit
 	Outfitter_RegisterEvent(this, "PLAYER_TARGET_CHANGED", Outfitter_TargetChanged);
+	Outfitter_RegisterEvent(this, "BigWigs_Pulltimer", Outfitter_BigWigsPulltimer);
 
 	-- Tabs
 
@@ -1040,6 +1041,10 @@ function Outfitter_TargetChangedDelayedEvent()
 		Outfitter_SetSpecialOutfitEnabled("DemonTrash", false);
 		Outfitter_SetSpecialOutfitEnabled("Critter", false);
 	end
+end
+
+function Outfitter_BigWigsPulltimer(pEvent, pDuration, pRequester)
+	Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 end
 
 function Outfitter_InventoryChanged(pEvent)

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -358,6 +358,7 @@ local Outfitter_cSpecialOutfitDescriptions = {
 	BeastTrash = Outfitter_cBeastTrashOutfitDescription,
 	UndeadTrash = Outfitter_cUndeadTrashOutfitDescription,
 	DemonTrash = Outfitter_cDemonTrashOutfitDescription,
+	NonCombat = Outfitter_cNonCombatOutfitDescription,
 };
 
 -- Note that zone special outfits will be worn in the order
@@ -917,10 +918,20 @@ end
 
 function Outfitter_RegenEnabled(pEvent)
 	gOutfitter_InCombat = false;
+
+	-- Check if any shapeshift outfit is active for any class
+	for _, specialIDInfo in pairs(Outfitter_cShapeshiftSpecialIDs) do
+		if gOutfitter_SpecialState[specialIDInfo.ID] then
+			return; -- A shapeshift form is active, so don't apply the NonCombat outfit
+		end
+	end
+
+	Outfitter_SetSpecialOutfitEnabled("NonCombat", true);
 end
 
 function Outfitter_RegenDisabled(pEvent)
 	gOutfitter_InCombat = true;
+	Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 end
 
 function Outfitter_PlayerDead(pEvent)
@@ -4001,12 +4012,17 @@ end
 
 function Outfitter_UpdateShapeshiftState()
 	local vNumForms = GetNumShapeshiftForms();
+	local isAnyFormActive = false;
 
 	for vIndex = 1, vNumForms do
 		local vTexture, vName, vIsActive, vIsCastable = GetShapeshiftFormInfo(vIndex);
 		local vSpecialID = Outfitter_cShapeshiftSpecialIDs[vName];
 
 		if vSpecialID then
+			if vIsActive then
+				isAnyFormActive = true;
+			end
+
 			if not vIsActive then
 				vIsActive = false;
 			end
@@ -4020,6 +4036,12 @@ function Outfitter_UpdateShapeshiftState()
 				Outfitter_SetSpecialOutfitEnabled(vSpecialID.ID, vIsActive);
 			end
 		end
+	end
+
+	if not isAnyFormActive and not gOutfitter_InCombat then
+		Outfitter_SetSpecialOutfitEnabled("NonCombat", true);
+	else
+		Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 	end
 end
 
@@ -4500,6 +4522,9 @@ function Outfitter_InitializeSpecialOccassionOutfits()
 	-- Create the city outfit
 
 	Outfitter_CreateEmptySpecialOccassionOutfit("City", Outfitter_cCityOutfit);
+
+	-- Create the NonCombat outfit
+	Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
 
 	-- Create class-specific outfits
 

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -762,6 +762,7 @@ function Outfitter_PlayerLeavingWorld()
 end
 
 function Outfitter_PlayerEnteringWorld()
+	Outfitter_UpdateZone();
 	OutfitterItemList_FlushEquippableItems();
 
 	Outfitter_RegenEnabled();
@@ -4526,7 +4527,13 @@ function Outfitter_InitializeSpecialOccassionOutfits()
 	Outfitter_CreateEmptySpecialOccassionOutfit("City", Outfitter_cCityOutfit);
 
 	-- Create the NonCombat outfit
-	Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
+	vOutfit = Outfitter_GetSpecialOutfit("NonCombat");
+	if not vOutfit then
+		Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
+		vOutfit = Outfitter_GetSpecialOutfit("NonCombat");
+		vOutfit.BGDisabled = true;
+		vOutfit.InstDisabled = true;
+	end
 
 	-- Create class-specific outfits
 

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -695,7 +695,6 @@ function Outfitter_OnLoad()
 
 	-- For boss/trash outfit
 	Outfitter_RegisterEvent(this, "PLAYER_TARGET_CHANGED", Outfitter_TargetChanged);
-	Outfitter_RegisterEvent(this, "BigWigs_Pulltimer", Outfitter_BigWigsPulltimer);
 
 	-- Tabs
 
@@ -1043,9 +1042,7 @@ function Outfitter_TargetChangedDelayedEvent()
 	end
 end
 
-function Outfitter_BigWigsPulltimer(pEvent, pDuration, pRequester)
-	Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
-end
+
 
 function Outfitter_InventoryChanged(pEvent)
 	if arg1 ~= "player" then

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -292,6 +292,7 @@ local Outfitter_cClassSpecialOutfits = {
 		{ Name = Outfitter_cDruidAquaticForm, SpecialID = "Aquatic" },
 		{ Name = Outfitter_cDruidTravelForm, SpecialID = "Travel" },
 		{ Name = Outfitter_cDruidMoonkinForm, SpecialID = "Moonkin" },
+		{ Name = Outfitter_cDruidTreeForm, SpecialID = "Tree" },
 	},
 
 	Priest = {
@@ -533,6 +534,7 @@ local Outfitter_cShapeshiftSpecialIDs = {
 	[Outfitter_cTravelForm] = { ID = "Travel" },
 	[Outfitter_cDireBearForm] = { ID = "Bear" },
 	[Outfitter_cMoonkinForm] = { ID = "Moonkin" },
+	[Outfitter_cTreeForm] = { ID = "Tree" },
 
 	-- Rogues
 

--- a/OutfitterStrings.lua
+++ b/OutfitterStrings.lua
@@ -52,6 +52,9 @@ Outfitter_cBeastTrashOutfit = "Beast Trash Mobs";
 Outfitter_cUndeadTrashOutfit = "Undead Trash Mobs";
 Outfitter_cDemonTrashOutfit = "Demon Trash Mobs";
 
+Outfitter_cNonCombatOutfit = "Non-Combat";
+
+
 Outfitter_cMountSpeedFormat = "Increases speed by (%d+)%%."; -- For detecting when mounted
 
 Outfitter_cBagsFullError = "Outfitter: Can't remove %s because all bags are full";
@@ -274,6 +277,8 @@ Outfitter_cCritterOutfitDescription = "This outfit will automatically be worn wh
 Outfitter_cBeastTrashOutfitDescription = "This outfit will automatically be worn whenever you target beasts level <63 mobs";
 Outfitter_cUndeadTrashOutfitDescription = "This outfit will automatically be worn whenever you target undead level <63 mobs";
 Outfitter_cDemonTrashOutfitDescription = "This outfit will automatically be worn whenever you target demons level <63 mobs";
+Outfitter_cNonCombatOutfitDescription = "This outfit will automatically be worn whenever you are out of combat.";
+
 
 Outfitter_cKeyBinding = "Key Binding";
 

--- a/OutfitterStrings.lua
+++ b/OutfitterStrings.lua
@@ -322,6 +322,8 @@ Outfitter_cAquaticForm = "Aquatic Form";
 Outfitter_cTravelForm = "Travel Form";
 Outfitter_cDireBearForm = "Dire Bear Form";
 Outfitter_cMoonkinForm = "Moonkin Form";
+Outfitter_cTreeForm = "Tree of Life Form";
+
 
 Outfitter_cGhostWolfForm = "Ghost Wolf";
 
@@ -332,6 +334,7 @@ Outfitter_cDruidCatForm = "Druid: Cat Form";
 Outfitter_cDruidAquaticForm = "Druid: Aquatic Form";
 Outfitter_cDruidTravelForm = "Druid: Travel Form";
 Outfitter_cDruidMoonkinForm = "Druid: Moonkin Form";
+Outfitter_cDruidTreeForm = "Druid: Tree Form";
 
 Outfitter_cPriestShadowform = "Priest: Shadowform";
 


### PR DESCRIPTION
- Added support for Tree of Life Druid form outfit management
- Implemented NonCombat outfit system with automatic state management:
  * Automatically disables when entering combat
  * Disables when any Druid form is active
  * Re-enables when returning to normal form and out of combat
