### PR TITLE
Store current zone when initializing Outfitter

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -726,6 +726,8 @@ function Outfitter_OnLoad()
 
 	SLASH_OUTFITTER1 = "/outfitter";
 
+	gOutfitter_CurrentZone = GetZoneText();
+	
 	-- Fake a leaving world event to suspend inventory/bag
 	-- updating until loading is completed
 


### PR DESCRIPTION
Fixes #14 , atleast in instances, should fix for pvp as well