### PR TITLE
Add Tree of Life Form support for Druid

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -327,6 +327,7 @@ local Outfitter_cClassSpecialOutfits = {
 		{ Name = Outfitter_cDruidAquaticForm, SpecialID = "Aquatic" },
 		{ Name = Outfitter_cDruidTravelForm, SpecialID = "Travel" },
 		{ Name = Outfitter_cDruidMoonkinForm, SpecialID = "Moonkin" },
+		{ Name = Outfitter_cDruidTreeForm, SpecialID = "Tree" },
 	},
 
 	Priest = {
@@ -570,6 +571,7 @@ local Outfitter_cShapeshiftSpecialIDs = {
 	[Outfitter_cTravelForm] = { ID = "Travel" },
 	[Outfitter_cDireBearForm] = { ID = "Bear" },
 	[Outfitter_cMoonkinForm] = { ID = "Moonkin" },
+	[Outfitter_cTreeForm] = { ID = "Tree" },
 
 	-- Rogues
 

--- a/OutfitterStrings.lua
+++ b/OutfitterStrings.lua
@@ -324,6 +324,8 @@ Outfitter_cAquaticForm = "Aquatic Form";
 Outfitter_cTravelForm = "Travel Form";
 Outfitter_cDireBearForm = "Dire Bear Form";
 Outfitter_cMoonkinForm = "Moonkin Form";
+Outfitter_cTreeForm = "Tree of Life Form";
+
 
 Outfitter_cGhostWolfForm = "Ghost Wolf";
 
@@ -334,6 +336,7 @@ Outfitter_cDruidCatForm = "Druid: Cat Form";
 Outfitter_cDruidAquaticForm = "Druid: Aquatic Form";
 Outfitter_cDruidTravelForm = "Druid: Travel Form";
 Outfitter_cDruidMoonkinForm = "Druid: Moonkin Form";
+Outfitter_cDruidTreeForm = "Druid: Tree Form";
 
 Outfitter_cPriestShadowform = "Priest: Shadowform";
 


### PR DESCRIPTION
This update introduces the Tree of Life Form for Druids, adding the corresponding special ID and string definitions to enhance outfit management functionality.