### PR TITLE
Optimize memory usage and improve event handling

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -327,6 +327,7 @@ local Outfitter_cClassSpecialOutfits = {
 		{ Name = Outfitter_cDruidAquaticForm, SpecialID = "Aquatic" },
 		{ Name = Outfitter_cDruidTravelForm, SpecialID = "Travel" },
 		{ Name = Outfitter_cDruidMoonkinForm, SpecialID = "Moonkin" },
+		{ Name = Outfitter_cDruidTreeForm, SpecialID = "Tree" },
 	},
 
 	Priest = {
@@ -570,6 +571,7 @@ local Outfitter_cShapeshiftSpecialIDs = {
 	[Outfitter_cTravelForm] = { ID = "Travel" },
 	[Outfitter_cDireBearForm] = { ID = "Bear" },
 	[Outfitter_cMoonkinForm] = { ID = "Moonkin" },
+	[Outfitter_cTreeForm] = { ID = "Tree" },
 
 	-- Rogues
 

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4160,15 +4160,17 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 			or vOutfit.Disabled
 			or (pEnable and vOutfit.BGDisabled and Outfitter_InBattlegroundZone())
 			or (pEnable and vOutfit.InstDisabled and Outfitter_InInstanceZone()) then
-		return ;
+		return;
 	end
 
 	if pEnable then
-		-- Start monitoring health and mana if it's the dining outfit
 
+		-- Start monitoring health and mana if it's the dining outfit
+		-- If enabling the Dining outfit, disable NonCombat outfit
 		if pSpecialID == "Dining" then
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_HEALTH");
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_MANA");
+            Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 		end
 
 		--

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -811,6 +811,7 @@ function Outfitter_PlayerLeavingWorld()
 end
 
 function Outfitter_PlayerEnteringWorld()
+	Outfitter_UpdateZone();
 	OutfitterItemList_FlushEquippableItems();
 
 	-- Clear BOE cache on login/reload
@@ -4631,7 +4632,13 @@ function Outfitter_InitializeSpecialOccassionOutfits()
 	Outfitter_CreateEmptySpecialOccassionOutfit("City", Outfitter_cCityOutfit);
 
 	-- Create the NonCombat outfit
-	Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
+	vOutfit = Outfitter_GetSpecialOutfit("NonCombat");
+	if not vOutfit then
+		Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
+		vOutfit = Outfitter_GetSpecialOutfit("NonCombat");
+		vOutfit.BGDisabled = true;
+		vOutfit.InstDisabled = true;
+	end
 
 	-- Create class-specific outfits
 

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4170,7 +4170,7 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 		if pSpecialID == "Dining" then
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_HEALTH");
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_MANA");
-            Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
+            --Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 		end
 
 		--
@@ -4185,6 +4185,8 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 
 		if pSpecialID == "ArgentDawn" then
 			vWearBelowOutfit = Outfitter_GetSpecialOutfit("Riding");
+        elseif pSpecialID == "NonCombat" then
+            vWearBelowOutfit = Outfitter_GetSpecialOutfit("Dining");
 		end
 
 		--

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -720,6 +720,7 @@ function Outfitter_OnLoad()
 	-- For monitoring plaguelands and battlegrounds
 
 	Outfitter_RegisterEvent(this, "ZONE_CHANGED_NEW_AREA", Outfitter_UpdateZone);
+	gOutfitter_CurrentZone = GetZoneText();
 
 	-- For monitoring player combat state
 

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4166,11 +4166,9 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 	if pEnable then
 
 		-- Start monitoring health and mana if it's the dining outfit
-		-- If enabling the Dining outfit, disable NonCombat outfit
 		if pSpecialID == "Dining" then
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_HEALTH");
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_MANA");
-            --Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 		end
 
 		--
@@ -4185,8 +4183,8 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 
 		if pSpecialID == "ArgentDawn" then
 			vWearBelowOutfit = Outfitter_GetSpecialOutfit("Riding");
-        elseif pSpecialID == "NonCombat" then
-            vWearBelowOutfit = Outfitter_GetSpecialOutfit("Dining");
+		elseif pSpecialID == "NonCombat" then
+			vWearBelowOutfit = Outfitter_GetSpecialOutfit("Dining");
 		end
 
 		--

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4530,6 +4530,7 @@ function Outfitter_Initialize()
 	-- Make sure the outfit state is good
 
 	Outfitter_SetSpecialOutfitEnabled("Riding", false);
+	Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 	Outfitter_SetSpecialOutfitEnabled("Spirit", false);
 	Outfitter_UpdateAuraStates();
 

--- a/OutfitterStrings.lua
+++ b/OutfitterStrings.lua
@@ -53,6 +53,9 @@ Outfitter_cBeastTrashOutfit = "Beast Trash Mobs";
 Outfitter_cUndeadTrashOutfit = "Undead Trash Mobs";
 Outfitter_cDemonTrashOutfit = "Demon Trash Mobs";
 
+Outfitter_cNonCombatOutfit = "Non-Combat";
+
+
 Outfitter_cMountSpeedFormat = "Increases speed by (%d+)%%."; -- For detecting when mounted
 
 Outfitter_cBagsFullError = "Outfitter: Can't remove %s because all bags are full";
@@ -276,6 +279,8 @@ Outfitter_cCritterOutfitDescription = "This outfit will automatically be worn wh
 Outfitter_cBeastTrashOutfitDescription = "This outfit will automatically be worn whenever you target beasts level <63 mobs";
 Outfitter_cUndeadTrashOutfitDescription = "This outfit will automatically be worn whenever you target undead level <63 mobs";
 Outfitter_cDemonTrashOutfitDescription = "This outfit will automatically be worn whenever you target demons level <63 mobs";
+Outfitter_cNonCombatOutfitDescription = "This outfit will automatically be worn whenever you are out of combat.";
+
 
 Outfitter_cKeyBinding = "Key Binding";
 

--- a/OutfitterStrings.lua
+++ b/OutfitterStrings.lua
@@ -324,6 +324,8 @@ Outfitter_cAquaticForm = "Aquatic Form";
 Outfitter_cTravelForm = "Travel Form";
 Outfitter_cDireBearForm = "Dire Bear Form";
 Outfitter_cMoonkinForm = "Moonkin Form";
+Outfitter_cTreeForm = "Tree of Life Form";
+
 
 Outfitter_cGhostWolfForm = "Ghost Wolf";
 
@@ -334,6 +336,7 @@ Outfitter_cDruidCatForm = "Druid: Cat Form";
 Outfitter_cDruidAquaticForm = "Druid: Aquatic Form";
 Outfitter_cDruidTravelForm = "Druid: Travel Form";
 Outfitter_cDruidMoonkinForm = "Druid: Moonkin Form";
+Outfitter_cDruidTreeForm = "Druid: Tree Form";
 
 Outfitter_cPriestShadowform = "Priest: Shadowform";
 


### PR DESCRIPTION
- Cache outfit names table to avoid string allocations in Outfitter_UpdateCurrentOutfit
- Cache aura states table to avoid creating new table on each Outfitter_GetPlayerAuraStates call
- Initialize gOutfitter_CurrentTarget as nil instead of calling UnitName at load time
- Cancel pending scheduled events in Outfitter_PlayerLeavingWorld to prevent memory leaks
- Cancel pending events before scheduling new ones in Outfitter_TargetChanged
- Improve Outfitter_TargetChangedDelayedEvent logic to handle nil target separately
- Remove unused vExpectedEquippableItems parameter passing
- Add nil protection in Outfitter_TestAmmoSlot debug output