### PR TITLE
Add NonCombat outfit support

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4160,15 +4160,17 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 			or vOutfit.Disabled
 			or (pEnable and vOutfit.BGDisabled and Outfitter_InBattlegroundZone())
 			or (pEnable and vOutfit.InstDisabled and Outfitter_InInstanceZone()) then
-		return ;
+		return;
 	end
 
 	if pEnable then
-		-- Start monitoring health and mana if it's the dining outfit
 
+		-- Start monitoring health and mana if it's the dining outfit
+		-- If enabling the Dining outfit, disable NonCombat outfit
 		if pSpecialID == "Dining" then
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_HEALTH");
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_MANA");
+            Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 		end
 
 		--

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -811,6 +811,7 @@ function Outfitter_PlayerLeavingWorld()
 end
 
 function Outfitter_PlayerEnteringWorld()
+	Outfitter_UpdateZone();
 	OutfitterItemList_FlushEquippableItems();
 
 	-- Clear BOE cache on login/reload
@@ -4631,7 +4632,13 @@ function Outfitter_InitializeSpecialOccassionOutfits()
 	Outfitter_CreateEmptySpecialOccassionOutfit("City", Outfitter_cCityOutfit);
 
 	-- Create the NonCombat outfit
-	Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
+	vOutfit = Outfitter_GetSpecialOutfit("NonCombat");
+	if not vOutfit then
+		Outfitter_CreateEmptySpecialOccassionOutfit("NonCombat", Outfitter_cNonCombatOutfit);
+		vOutfit = Outfitter_GetSpecialOutfit("NonCombat");
+		vOutfit.BGDisabled = true;
+		vOutfit.InstDisabled = true;
+	end
 
 	-- Create class-specific outfits
 

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4170,7 +4170,7 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 		if pSpecialID == "Dining" then
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_HEALTH");
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_MANA");
-            Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
+            --Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 		end
 
 		--
@@ -4185,6 +4185,8 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 
 		if pSpecialID == "ArgentDawn" then
 			vWearBelowOutfit = Outfitter_GetSpecialOutfit("Riding");
+        elseif pSpecialID == "NonCombat" then
+            vWearBelowOutfit = Outfitter_GetSpecialOutfit("Dining");
 		end
 
 		--

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4166,11 +4166,9 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 	if pEnable then
 
 		-- Start monitoring health and mana if it's the dining outfit
-		-- If enabling the Dining outfit, disable NonCombat outfit
 		if pSpecialID == "Dining" then
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_HEALTH");
 			Outfitter_ResumeEvent(OutfitterFrame, "UNIT_MANA");
-            --Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 		end
 
 		--
@@ -4185,8 +4183,8 @@ function Outfitter_SetSpecialOutfitEnabled(pSpecialID, pEnable)
 
 		if pSpecialID == "ArgentDawn" then
 			vWearBelowOutfit = Outfitter_GetSpecialOutfit("Riding");
-        elseif pSpecialID == "NonCombat" then
-            vWearBelowOutfit = Outfitter_GetSpecialOutfit("Dining");
+		elseif pSpecialID == "NonCombat" then
+			vWearBelowOutfit = Outfitter_GetSpecialOutfit("Dining");
 		end
 
 		--

--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -4530,6 +4530,7 @@ function Outfitter_Initialize()
 	-- Make sure the outfit state is good
 
 	Outfitter_SetSpecialOutfitEnabled("Riding", false);
+	Outfitter_SetSpecialOutfitEnabled("NonCombat", false);
 	Outfitter_SetSpecialOutfitEnabled("Spirit", false);
 	Outfitter_UpdateAuraStates();
 

--- a/OutfitterStrings.lua
+++ b/OutfitterStrings.lua
@@ -53,6 +53,9 @@ Outfitter_cBeastTrashOutfit = "Beast Trash Mobs";
 Outfitter_cUndeadTrashOutfit = "Undead Trash Mobs";
 Outfitter_cDemonTrashOutfit = "Demon Trash Mobs";
 
+Outfitter_cNonCombatOutfit = "Non-Combat";
+
+
 Outfitter_cMountSpeedFormat = "Increases speed by (%d+)%%."; -- For detecting when mounted
 
 Outfitter_cBagsFullError = "Outfitter: Can't remove %s because all bags are full";
@@ -276,6 +279,8 @@ Outfitter_cCritterOutfitDescription = "This outfit will automatically be worn wh
 Outfitter_cBeastTrashOutfitDescription = "This outfit will automatically be worn whenever you target beasts level <63 mobs";
 Outfitter_cUndeadTrashOutfitDescription = "This outfit will automatically be worn whenever you target undead level <63 mobs";
 Outfitter_cDemonTrashOutfitDescription = "This outfit will automatically be worn whenever you target demons level <63 mobs";
+Outfitter_cNonCombatOutfitDescription = "This outfit will automatically be worn whenever you are out of combat.";
+
 
 Outfitter_cKeyBinding = "Key Binding";
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                 
  Adds a new automatic outfit that equips when the player is out of combat and not in any shapeshift form.                                                                  
                                                                                                                                                                             
  - NonCombat outfit is created automatically (disabled by default)                                                                                                          
  - Automatically disabled in battlegrounds and instances                                                                                                                    
  - Works below Dining outfit priority (Dining takes precedence when both are active)                                                                                        
  - Respects all shapeshift forms (Cat, Bear, Moonkin, Tree of Life, etc.)                                                                                                   
                                                                                                                                                                             
  ## Use case                                                                                                                                                                
  Useful for equipping items with out-of-combat bonuses (spirit gear for mana regen, fishing gear, fun items) that automatically swap out when entering combat.    